### PR TITLE
Fixed asset form fields label style

### DIFF
--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -56,8 +56,9 @@ table {
 }
 
 .required-label:after {
-    content: " *";
+    content: " *" !important;
     color:red;
+    position: initial !important;
 }
 
 /*Tab Styles*/


### PR DESCRIPTION
Override Bootstrap style for field labels "after" within an element with class "form-floating".